### PR TITLE
Add Sample Git Submodule

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,3 +11,15 @@ jobs:
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4.2.0
+        with:
+          submodules: recursive
+
+      - name: Assert Git Submodules
+        run: |
+          ACTUAL=$(git submodule status --recursive)
+          EXPECTED=" bea29a84b6c55a49fef34be3e7a17498c633b6d9 project-starter (v1.2.0)"
+          if [ "$ACTUAL" != "$EXPECTED" ]; then
+            echo "actual: $ACTUAL"
+            echo "expected: $EXPECTED"
+            exit 1
+          fi

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "project-starter"]
+	path = project-starter
+	url = https://github.com/threeal/project-starter.git


### PR DESCRIPTION
This pull request resolves #3 by adding the [Project Starter](https://github.com/threeal/project-starter) project to this repository as a sample Git submodule. This change also updates the test workflow to assert whether the Git submodules are initialized correctly.