### PR TITLE
Fix Git Submodule Assertion in CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,8 +11,9 @@ jobs:
     steps:
       - name: Checkout Project
         uses: actions/checkout@v4.2.1
-        with:
-          submodules: recursive
+
+      - name: Initialize Submodules
+        run: git submodule update --init --recursive
 
       - name: Assert Git Submodules
         run: |


### PR DESCRIPTION
This pull request resolves #9 by modifying the Test workflow to manually initialize Git submodules instead of relying on initialization by `actions/checkout`.